### PR TITLE
Refactor TypeScript 'Private' to native private class members

### DIFF
--- a/cypress/e2e/basic.spec.cy.ts
+++ b/cypress/e2e/basic.spec.cy.ts
@@ -79,7 +79,7 @@ function annotations(screenSize: ScreenSize) {
     it("should display sanitised annotation text", () => {});
 
     it("should display the correct region in OpenSeadragon", () => {
-      cy.window().then((window: WindowWithStoriiiesViewer) => {
+      cy.window().then((window) => {
         cy.get('#viewer[data-loaded="true"]').then(() => {
           if (!window.storiiiesViewerInstance) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,15 +5,16 @@ import {
   AnnotationPage,
   Annotation,
 } from "manifesto.js";
-import { sanitiseHTML } from "./utils";
 import DOMPurify from "dompurify";
 import OpenSeadragon from "openseadragon";
+
+import { sanitiseHTML } from "./utils";
 
 import arrowIcon from "./images/arrow.svg?raw";
 import showIcon from "./images/eye.svg?raw";
 import hideIcon from "./images/hide.svg?raw";
 
-interface IStoriiiesViewerConfig {
+export interface IStoriiiesViewerConfig {
   container: HTMLElement | Element | string | null;
   manifestUrl: string;
 }


### PR DESCRIPTION
- **Pivotal ticket**: [#185844093](https://www.pivotaltracker.com/story/show/185844093)

# What does this Pull Request do?
Previously users were only warned that they cannot use a certain property or method if they used TypeScript. With these changes TypeScript is still aware of what a ECMAScript private class member is, but it will extend the same protections to JavaScript development environments, and prevent access where it's not desirable.

Having a slimmed back public API should reduce the noise so that users just see the things that might be useful to them.

The approach I took when deciding what to expose was:

**Properties**
A lot of these are potentially interesting and useful, particularly the ones which pertain to the current state of a viewer, and references to it's elements, and the gettters and setters for various state values. What's not useful, and shouldn't be relied on are the values behind the getters/setters, and other internal values.

**Methods**
Not many (zero) of these are that interesting or useful to a user. Some are used simply once in order to bootstrap the app, whereas others are only useful when used in an internal context, and any interesting values should be in the properties. The best way for someone to interact with a storiiiesViewer instance pragmatically if they really wanted to is to manually manipulate the annotation index.

## Other notes
- ~~I changed the default export to also include a named export~~ As I discovered this creates a PITA for consuming the module via UMD/IIFE (In the browser, via a script tag), I reverted this to just be a default export for now
- I exported the interface for the config. If we decide to use TSDoc, this makes things a little nice and exposes it in the documentation.
- I noticed a rogue legacy usage of `windowWithStoriiiesViewer` in one of the tests

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- [ ] Cypress tests?
