### PR TITLE
Account for `\n` and `<br>` appearing in same string

### DIFF
--- a/cypress/e2e/basic.spec.cy.ts
+++ b/cypress/e2e/basic.spec.cy.ts
@@ -58,11 +58,31 @@ function rendering(screenSize: ScreenSize) {
       cy.get("#viewer[data-loaded='true']");
     });
 
+    // Plain text should include converted break tags
     it("Should initially display the label from the manifest", () => {
       cy.get("#storiiies-viewer-0__info-text").should(
         "have.html",
         `\n        <h1 class="storiiies-viewer__title storiiies-viewer__text-section">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h1>\n        <div class="storiiies-viewer__text-section">Pellentesque tempor ante non congue pulvinar.<br><br>Maecenas non ipsum non metus imperdiet facilisis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Praesent sem felis, porta eu nisl in, rhoncus luctus nunc.<br>Morbi bibendum, eros eu sollicitudin egestas, nisi dui convallis nisi, sed lacinia velit augue eu lectus. In enim est, elementum ac elit a, ultricies pellentesque nibh.</div>\n        <div class="storiiies-viewer__text-section"><strong>Attribution:</strong> Provided courtesy of Example Institution</div>\n      `,
       );
+    });
+  });
+
+  describe(`Rendering manifest with mixed HTML/plain text summary (${screenSize.label})`, () => {
+    beforeEach(() =>
+      setupViewer(
+        screenSize,
+        "http://localhost:43110/manifests/mixed-html-plain-summary-v3/manifest.json",
+      ),
+    );
+    it("Should render an Openseadragon viewer", () => {
+      cy.get("#viewer[data-loaded='true']");
+    });
+
+    // Something judged to be HTML (starts with < and ends with >) should not including any converted break tags
+    it("Should not convert \\n's to break tags", () => {
+      cy.get("#storiiies-viewer-0__info-text")
+        .invoke("html")
+        .should("not.contain", "<br>");
     });
   });
 }

--- a/cypress/fixtures/manifests/mixed-html-plain-summary-v3/manifest.json
+++ b/cypress/fixtures/manifests/mixed-html-plain-summary-v3/manifest.json
@@ -1,0 +1,85 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:43110/manifests/standard-v3/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Lorem ipsum dolor sit amet, consectetur adipiscing elit"]
+  },
+  "summary": {
+    "en": [
+      "<div><p><em>Pellentesque tempor \nante non congue pulvinar.</em> Maecenas non ipsum non metus imperdiet facilisis. Vestibulum ante ipsum primis in <strong>faucibus</strong> orci luctus et ultrices posuere cubilia curae; Praesent sem felis, porta eu nisl in\n, rhoncus luctus nunc. Morbi bibendum, eros eu sollicitudin egestas, nisi dui convallis nisi, sed lacinia velit augue eu lectus. In enim est, elementum ac elit a, ultricies pellentesque nibh.\n</p></div>"
+    ]
+  },
+  "requiredStatement": {
+    "label": { "en": ["Attribution"] },
+    "value": { "en": ["Provided courtesy of Example Institution"] }
+  },
+  "items": [
+    {
+      "id": "http://localhost:43110/images/exact-tiles/canvases/1",
+      "type": "Canvas",
+      "height": 2048,
+      "width": 2048,
+      "items": [
+        {
+          "id": "http://localhost:43110/images/exact-tiles/pages/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:43110/images/exact-tiles/annotations/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "http://localhost:43110/images/exact-tiles/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2048,
+                "width": 2048,
+                "service": [
+                  {
+                    "id": "http://localhost:43110/images/exact-tiles",
+                    "profile": "level0",
+                    "type": "ImageService3"
+                  }
+                ]
+              },
+              "target": "http://localhost:43110/images/exact-tiles/canvases/1"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "http://localhost:43110/annotations/standard-v3/page-1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:43110/annotations/standard-v3/page-1/annotation/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "value": "Nullam sit amet egestas metus.\n\nSed dictum mattis erat feugiat gravida",
+                "language": "en",
+                "format": "text/plain"
+              },
+              "target": "http://localhost:43110/images/exact-tiles/canvases/1#xywh=265.53218,661.3333,100,200"
+            },
+            {
+              "id": "http://localhost:43110/annotations/standard-v3/page-1/annotation/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "value": "<div><p><strong onclick=\"alert('malicious code')\">Suspendisse lacinia enim lorem</strong>, sit amet interdum odio dignissim et. <marquee style=\"color:red;\">Curabitur ultricies felis</marquee> non sagittis commodo.</p><p>Proin finibus imperdiet lectus quis imperdiet. Maecenas at rhoncus nibh, ac lobortis ante. Nam et ligula a dui <a href=\"https://www.google.com\">consectetur consectetur</a>. Suspendisse non nisi turpis.</p></div>",
+                "language": "en",
+                "format": "text/html"
+              },
+              "target": "http://localhost:43110/images/exact-tiles/canvases/1#xywh=-20,242,200,120"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/classes/StoriiiesViewer.html
+++ b/docs/api/classes/StoriiiesViewer.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">StoriiiesViewer</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L60">StoriiiesViewer.ts:60</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L60">StoriiiesViewer.ts:60</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -93,7 +93,7 @@
 <h5><span class="tsd-kind-parameter">config</span>: <a href="../interfaces/StoriiiesViewerConfig.html" class="tsd-signature-type tsd-kind-interface">StoriiiesViewerConfig</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="StoriiiesViewer.html" class="tsd-signature-type tsd-kind-class">StoriiiesViewer</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L162">StoriiiesViewer.ts:162</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L162">StoriiiesViewer.ts:162</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__activeAnnotationIndex" class="tsd-anchor"></a>
@@ -103,7 +103,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L64">StoriiiesViewer.ts:64</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L64">StoriiiesViewer.ts:64</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__activeCanvasIndex" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#_<wbr/>active<wbr/>Canvas<wbr/>Index</span><a href="#__activeCanvasIndex" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#_<wbr/>active<wbr/>Canvas<wbr/>Index</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
@@ -111,7 +111,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L68">StoriiiesViewer.ts:68</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L68">StoriiiesViewer.ts:68</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__showInfoArea" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#_<wbr/>show<wbr/>Info<wbr/>Area</span><a href="#__showInfoArea" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#_<wbr/>show<wbr/>Info<wbr/>Area</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
@@ -119,7 +119,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L70">StoriiiesViewer.ts:70</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L70">StoriiiesViewer.ts:70</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_annotationIndexCeiling" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#annotation<wbr/>Index<wbr/>Ceiling</span><a href="#_annotationIndexCeiling" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#annotation<wbr/>Index<wbr/>Ceiling</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -127,7 +127,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L74">StoriiiesViewer.ts:74</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L74">StoriiiesViewer.ts:74</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_annotationIndexFloor" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#annotation<wbr/>Index<wbr/>Floor</span><a href="#_annotationIndexFloor" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#annotation<wbr/>Index<wbr/>Floor</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = -1</span></div>
@@ -135,7 +135,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L72">StoriiiesViewer.ts:72</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L72">StoriiiesViewer.ts:72</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_prefersReducedMotion" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#prefers<wbr/>Reduced<wbr/>Motion</span><a href="#_prefersReducedMotion" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#prefers<wbr/>Reduced<wbr/>Motion</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -143,7 +143,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L76">StoriiiesViewer.ts:76</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L76">StoriiiesViewer.ts:76</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_statusCodes" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#status<wbr/>Codes</span><a href="#_statusCodes" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#status<wbr/>Codes</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">statusCodes</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -151,7 +151,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L78">StoriiiesViewer.ts:78</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L78">StoriiiesViewer.ts:78</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="DOMPurifyConfig" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>DOMPurify<wbr/>Config</span><a href="#DOMPurifyConfig" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">DOMPurify<wbr/>Config</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Config</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -159,7 +159,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L145">StoriiiesViewer.ts:145</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L145">StoriiiesViewer.ts:145</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="activeCanvasAnnotations" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>active<wbr/>Canvas<wbr/>Annotations</span><a href="#activeCanvasAnnotations" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">active<wbr/>Canvas<wbr/>Annotations</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Annotation</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
@@ -167,7 +167,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L125">StoriiiesViewer.ts:125</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L125">StoriiiesViewer.ts:125</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="annotationPages" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>annotation<wbr/>Pages</span><a href="#annotationPages" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">annotation<wbr/>Pages</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">AnnotationPage</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
@@ -175,7 +175,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L123">StoriiiesViewer.ts:123</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L123">StoriiiesViewer.ts:123</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="canvases" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>canvases</span><a href="#canvases" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">canvases</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Canvas</span><span class="tsd-signature-symbol">[]</span></div>
@@ -183,7 +183,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L121">StoriiiesViewer.ts:121</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L121">StoriiiesViewer.ts:121</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="containerElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>container<wbr/>Element</span><a href="#containerElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">container<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type ">HTMLElement</span><span class="tsd-signature-symbol"> = null</span></div>
@@ -191,7 +191,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L98">StoriiiesViewer.ts:98</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L98">StoriiiesViewer.ts:98</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="controlButtonElements" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>control<wbr/>Button<wbr/>Elements</span><a href="#controlButtonElements" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">control<wbr/>Button<wbr/>Elements</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">ControlButtons</span></div>
@@ -199,7 +199,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L139">StoriiiesViewer.ts:139</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L139">StoriiiesViewer.ts:139</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoAreaElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Area<wbr/>Element</span><a href="#infoAreaElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Area<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -207,7 +207,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L131">StoriiiesViewer.ts:131</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L131">StoriiiesViewer.ts:131</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoTextElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Text<wbr/>Element</span><a href="#infoTextElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Text<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -215,7 +215,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L135">StoriiiesViewer.ts:135</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L135">StoriiiesViewer.ts:135</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoToggleElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Toggle<wbr/>Element</span><a href="#infoToggleElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Toggle<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -223,7 +223,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L143">StoriiiesViewer.ts:143</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L143">StoriiiesViewer.ts:143</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="instanceId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>instance<wbr/>Id</span><a href="#instanceId" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">instance<wbr/>Id</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -231,7 +231,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L108">StoriiiesViewer.ts:108</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L108">StoriiiesViewer.ts:108</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="label" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>label</span><a href="#label" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">label</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
@@ -239,7 +239,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L112">StoriiiesViewer.ts:112</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L112">StoriiiesViewer.ts:112</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifest" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest</span><a href="#manifest" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Manifest</span></div>
@@ -247,7 +247,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L110">StoriiiesViewer.ts:110</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L110">StoriiiesViewer.ts:110</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifestUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest<wbr/>Url</span><a href="#manifestUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest<wbr/>Url</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -255,7 +255,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L104">StoriiiesViewer.ts:104</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L104">StoriiiesViewer.ts:104</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="requiredStatement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>required<wbr/>Statement</span><a href="#requiredStatement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">required<wbr/>Statement</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span><span class="tsd-kind-property">label</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span>    </span><span class="tsd-kind-property">value</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -270,7 +270,7 @@
 <h5><span class="tsd-kind-property">value</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L116">StoriiiesViewer.ts:116</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L116">StoriiiesViewer.ts:116</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="showCreditSlide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>show<wbr/>Credit<wbr/>Slide</span><a href="#showCreditSlide" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">show<wbr/>Credit<wbr/>Slide</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
@@ -278,7 +278,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L102">StoriiiesViewer.ts:102</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L102">StoriiiesViewer.ts:102</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="summary" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>summary</span><a href="#summary" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">summary</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -286,7 +286,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L114">StoriiiesViewer.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L114">StoriiiesViewer.ts:114</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="viewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>viewer</span><a href="#viewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">viewer</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Viewer</span></div>
@@ -294,7 +294,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L127">StoriiiesViewer.ts:127</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L127">StoriiiesViewer.ts:127</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_instanceCounter" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagPrivate">Private</code> <span>#instance<wbr/>Counter</span><a href="#_instanceCounter" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#instance<wbr/>Counter</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
@@ -302,7 +302,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L94">StoriiiesViewer.ts:94</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L94">StoriiiesViewer.ts:94</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Accessors</h2>
 <section class="tsd-panel tsd-member"><a id="activeAnnotationIndex" class="tsd-anchor"></a>
@@ -315,7 +315,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L399">StoriiiesViewer.ts:399</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L399">StoriiiesViewer.ts:399</a></li></ul></aside></li>
 <li class="tsd-signature" id="activeAnnotationIndex.activeAnnotationIndex-2"><span class="tsd-signature-symbol">set</span> activeAnnotationIndex<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">index</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the active annotation index and perform any necessary updates<br>Used to navigate between annotations</p>
@@ -328,7 +328,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L407">StoriiiesViewer.ts:407</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L407">StoriiiesViewer.ts:407</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member"><a id="activeCanvasIndex" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>active<wbr/>Canvas<wbr/>Index</span><a href="#activeCanvasIndex" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures">
@@ -339,7 +339,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L382">StoriiiesViewer.ts:382</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L382">StoriiiesViewer.ts:382</a></li></ul></aside></li>
 <li class="tsd-signature" id="activeCanvasIndex.activeCanvasIndex-2"><span class="tsd-signature-symbol">set</span> activeCanvasIndex<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">index</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the active canvas index and perform any necessary updates<br>Used to navigate between canvases</p>
@@ -352,7 +352,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L390">StoriiiesViewer.ts:390</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L390">StoriiiesViewer.ts:390</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member"><a id="showInfoArea" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>show<wbr/>Info<wbr/>Area</span><a href="#showInfoArea" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures">
@@ -363,7 +363,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L454">StoriiiesViewer.ts:454</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L454">StoriiiesViewer.ts:454</a></li></ul></aside></li>
 <li class="tsd-signature" id="showInfoArea.showInfoArea-2"><span class="tsd-signature-symbol">set</span> showInfoArea<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">value</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the showInfoArea value and perform any necessary updates<br>Used to toggle the info area visibility</p>
@@ -376,7 +376,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L462">StoriiiesViewer.ts:462</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L462">StoriiiesViewer.ts:462</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_creatTitleSlideMarkup" class="tsd-anchor"></a>
@@ -389,7 +389,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L571">StoriiiesViewer.ts:571</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L571">StoriiiesViewer.ts:571</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_createAnnotationSlideMarkup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#create<wbr/>Annotation<wbr/>Slide<wbr/>Markup</span><a href="#_createAnnotationSlideMarkup" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -400,7 +400,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L608">StoriiiesViewer.ts:608</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L608">StoriiiesViewer.ts:608</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_createCreditSlideMarkup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#create<wbr/>Credit<wbr/>Slide<wbr/>Markup</span><a href="#_createCreditSlideMarkup" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -411,7 +411,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L629">StoriiiesViewer.ts:629</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L629">StoriiiesViewer.ts:629</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_expandServiceID" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#expand<wbr/>ServiceID</span><a href="#_expandServiceID" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -427,7 +427,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L226">StoriiiesViewer.ts:226</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L226">StoriiiesViewer.ts:226</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getActiveCanvasAnnotations" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Active<wbr/>Canvas<wbr/>Annotations</span><a href="#_getActiveCanvasAnnotations" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -438,7 +438,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Annotation</span><span class="tsd-signature-symbol">[]</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L680">StoriiiesViewer.ts:680</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L680">StoriiiesViewer.ts:680</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getAnnotationPages" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Annotation<wbr/>Pages</span><a href="#_getAnnotationPages" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -450,7 +450,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">AnnotationPage</span><span class="tsd-signature-symbol">[]</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L638">StoriiiesViewer.ts:638</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L638">StoriiiesViewer.ts:638</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getRegion" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Region</span><a href="#_getRegion" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -466,7 +466,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type ">Rect</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L688">StoriiiesViewer.ts:688</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L688">StoriiiesViewer.ts:688</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_initManifest" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#init<wbr/>Manifest</span><a href="#_initManifest" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -477,7 +477,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L235">StoriiiesViewer.ts:235</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L235">StoriiiesViewer.ts:235</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_initViewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#init<wbr/>Viewer</span><a href="#_initViewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -488,7 +488,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L303">StoriiiesViewer.ts:303</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L303">StoriiiesViewer.ts:303</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_insertInfoAndControls" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#insert<wbr/>Info<wbr/>And<wbr/>Controls</span><a href="#_insertInfoAndControls" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -499,7 +499,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L485">StoriiiesViewer.ts:485</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L485">StoriiiesViewer.ts:485</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_logger" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#logger</span><a href="#_logger" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -517,7 +517,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L205">StoriiiesViewer.ts:205</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L205">StoriiiesViewer.ts:205</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_updateViewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#update<wbr/>Viewer</span><a href="#_updateViewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -528,7 +528,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L344">StoriiiesViewer.ts:344</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L344">StoriiiesViewer.ts:344</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/api/classes/StoriiiesViewer.html
+++ b/docs/api/classes/StoriiiesViewer.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">StoriiiesViewer</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L60">StoriiiesViewer.ts:60</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L60">StoriiiesViewer.ts:60</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -93,7 +93,7 @@
 <h5><span class="tsd-kind-parameter">config</span>: <a href="../interfaces/StoriiiesViewerConfig.html" class="tsd-signature-type tsd-kind-interface">StoriiiesViewerConfig</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="StoriiiesViewer.html" class="tsd-signature-type tsd-kind-class">StoriiiesViewer</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L162">StoriiiesViewer.ts:162</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L162">StoriiiesViewer.ts:162</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__activeAnnotationIndex" class="tsd-anchor"></a>
@@ -103,7 +103,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L64">StoriiiesViewer.ts:64</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L64">StoriiiesViewer.ts:64</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__activeCanvasIndex" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#_<wbr/>active<wbr/>Canvas<wbr/>Index</span><a href="#__activeCanvasIndex" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#_<wbr/>active<wbr/>Canvas<wbr/>Index</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
@@ -111,7 +111,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L68">StoriiiesViewer.ts:68</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L68">StoriiiesViewer.ts:68</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="__showInfoArea" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#_<wbr/>show<wbr/>Info<wbr/>Area</span><a href="#__showInfoArea" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#_<wbr/>show<wbr/>Info<wbr/>Area</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
@@ -119,7 +119,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L70">StoriiiesViewer.ts:70</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L70">StoriiiesViewer.ts:70</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_annotationIndexCeiling" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#annotation<wbr/>Index<wbr/>Ceiling</span><a href="#_annotationIndexCeiling" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#annotation<wbr/>Index<wbr/>Ceiling</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -127,7 +127,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L74">StoriiiesViewer.ts:74</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L74">StoriiiesViewer.ts:74</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_annotationIndexFloor" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#annotation<wbr/>Index<wbr/>Floor</span><a href="#_annotationIndexFloor" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#annotation<wbr/>Index<wbr/>Floor</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = -1</span></div>
@@ -135,7 +135,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L72">StoriiiesViewer.ts:72</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L72">StoriiiesViewer.ts:72</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_prefersReducedMotion" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#prefers<wbr/>Reduced<wbr/>Motion</span><a href="#_prefersReducedMotion" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#prefers<wbr/>Reduced<wbr/>Motion</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -143,7 +143,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L76">StoriiiesViewer.ts:76</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L76">StoriiiesViewer.ts:76</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_statusCodes" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#status<wbr/>Codes</span><a href="#_statusCodes" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#status<wbr/>Codes</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">statusCodes</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -151,7 +151,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L78">StoriiiesViewer.ts:78</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L78">StoriiiesViewer.ts:78</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="DOMPurifyConfig" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>DOMPurify<wbr/>Config</span><a href="#DOMPurifyConfig" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">DOMPurify<wbr/>Config</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Config</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -159,7 +159,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L145">StoriiiesViewer.ts:145</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L145">StoriiiesViewer.ts:145</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="activeCanvasAnnotations" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>active<wbr/>Canvas<wbr/>Annotations</span><a href="#activeCanvasAnnotations" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">active<wbr/>Canvas<wbr/>Annotations</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Annotation</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
@@ -167,7 +167,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L125">StoriiiesViewer.ts:125</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L125">StoriiiesViewer.ts:125</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="annotationPages" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>annotation<wbr/>Pages</span><a href="#annotationPages" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">annotation<wbr/>Pages</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">AnnotationPage</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
@@ -175,7 +175,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L123">StoriiiesViewer.ts:123</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L123">StoriiiesViewer.ts:123</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="canvases" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>canvases</span><a href="#canvases" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">canvases</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Canvas</span><span class="tsd-signature-symbol">[]</span></div>
@@ -183,7 +183,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L121">StoriiiesViewer.ts:121</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L121">StoriiiesViewer.ts:121</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="containerElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>container<wbr/>Element</span><a href="#containerElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">container<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type ">HTMLElement</span><span class="tsd-signature-symbol"> = null</span></div>
@@ -191,7 +191,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L98">StoriiiesViewer.ts:98</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L98">StoriiiesViewer.ts:98</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="controlButtonElements" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>control<wbr/>Button<wbr/>Elements</span><a href="#controlButtonElements" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">control<wbr/>Button<wbr/>Elements</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">ControlButtons</span></div>
@@ -199,7 +199,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L139">StoriiiesViewer.ts:139</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L139">StoriiiesViewer.ts:139</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoAreaElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Area<wbr/>Element</span><a href="#infoAreaElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Area<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -207,7 +207,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L131">StoriiiesViewer.ts:131</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L131">StoriiiesViewer.ts:131</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoTextElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Text<wbr/>Element</span><a href="#infoTextElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Text<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -215,7 +215,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L135">StoriiiesViewer.ts:135</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L135">StoriiiesViewer.ts:135</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="infoToggleElement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>info<wbr/>Toggle<wbr/>Element</span><a href="#infoToggleElement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">info<wbr/>Toggle<wbr/>Element</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">HTMLElement</span></div>
@@ -223,7 +223,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L143">StoriiiesViewer.ts:143</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L143">StoriiiesViewer.ts:143</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="instanceId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>instance<wbr/>Id</span><a href="#instanceId" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">instance<wbr/>Id</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
@@ -231,7 +231,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L108">StoriiiesViewer.ts:108</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L108">StoriiiesViewer.ts:108</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="label" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>label</span><a href="#label" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">label</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
@@ -239,7 +239,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L112">StoriiiesViewer.ts:112</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L112">StoriiiesViewer.ts:112</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifest" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest</span><a href="#manifest" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Manifest</span></div>
@@ -247,7 +247,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L110">StoriiiesViewer.ts:110</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L110">StoriiiesViewer.ts:110</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifestUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest<wbr/>Url</span><a href="#manifestUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest<wbr/>Url</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -255,7 +255,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L104">StoriiiesViewer.ts:104</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L104">StoriiiesViewer.ts:104</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="requiredStatement" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>required<wbr/>Statement</span><a href="#requiredStatement" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">required<wbr/>Statement</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span><span class="tsd-kind-property">label</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span>    </span><span class="tsd-kind-property">value</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -270,7 +270,7 @@
 <h5><span class="tsd-kind-property">value</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L116">StoriiiesViewer.ts:116</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L116">StoriiiesViewer.ts:116</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="showCreditSlide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>show<wbr/>Credit<wbr/>Slide</span><a href="#showCreditSlide" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">show<wbr/>Credit<wbr/>Slide</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
@@ -278,7 +278,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L102">StoriiiesViewer.ts:102</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L102">StoriiiesViewer.ts:102</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="summary" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>summary</span><a href="#summary" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">summary</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -286,7 +286,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L114">StoriiiesViewer.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L114">StoriiiesViewer.ts:114</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="viewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>viewer</span><a href="#viewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">viewer</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type ">Viewer</span></div>
@@ -294,7 +294,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L127">StoriiiesViewer.ts:127</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L127">StoriiiesViewer.ts:127</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_instanceCounter" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagPrivate">Private</code> <span>#instance<wbr/>Counter</span><a href="#_instanceCounter" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">#instance<wbr/>Counter</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
@@ -302,7 +302,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L94">StoriiiesViewer.ts:94</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L94">StoriiiesViewer.ts:94</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Accessors</h2>
 <section class="tsd-panel tsd-member"><a id="activeAnnotationIndex" class="tsd-anchor"></a>
@@ -315,7 +315,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L399">StoriiiesViewer.ts:399</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L399">StoriiiesViewer.ts:399</a></li></ul></aside></li>
 <li class="tsd-signature" id="activeAnnotationIndex.activeAnnotationIndex-2"><span class="tsd-signature-symbol">set</span> activeAnnotationIndex<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">index</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the active annotation index and perform any necessary updates<br>Used to navigate between annotations</p>
@@ -328,7 +328,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L407">StoriiiesViewer.ts:407</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L407">StoriiiesViewer.ts:407</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member"><a id="activeCanvasIndex" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>active<wbr/>Canvas<wbr/>Index</span><a href="#activeCanvasIndex" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures">
@@ -339,7 +339,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L382">StoriiiesViewer.ts:382</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L382">StoriiiesViewer.ts:382</a></li></ul></aside></li>
 <li class="tsd-signature" id="activeCanvasIndex.activeCanvasIndex-2"><span class="tsd-signature-symbol">set</span> activeCanvasIndex<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">index</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the active canvas index and perform any necessary updates<br>Used to navigate between canvases</p>
@@ -352,7 +352,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L390">StoriiiesViewer.ts:390</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L390">StoriiiesViewer.ts:390</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member"><a id="showInfoArea" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>show<wbr/>Info<wbr/>Area</span><a href="#showInfoArea" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures">
@@ -363,7 +363,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L454">StoriiiesViewer.ts:454</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L454">StoriiiesViewer.ts:454</a></li></ul></aside></li>
 <li class="tsd-signature" id="showInfoArea.showInfoArea-2"><span class="tsd-signature-symbol">set</span> showInfoArea<span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">value</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Set the showInfoArea value and perform any necessary updates<br>Used to toggle the info area visibility</p>
@@ -376,7 +376,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L462">StoriiiesViewer.ts:462</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L462">StoriiiesViewer.ts:462</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_creatTitleSlideMarkup" class="tsd-anchor"></a>
@@ -389,7 +389,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L571">StoriiiesViewer.ts:571</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L571">StoriiiesViewer.ts:571</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_createAnnotationSlideMarkup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#create<wbr/>Annotation<wbr/>Slide<wbr/>Markup</span><a href="#_createAnnotationSlideMarkup" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -400,7 +400,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L608">StoriiiesViewer.ts:608</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L608">StoriiiesViewer.ts:608</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_createCreditSlideMarkup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#create<wbr/>Credit<wbr/>Slide<wbr/>Markup</span><a href="#_createCreditSlideMarkup" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -411,7 +411,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L629">StoriiiesViewer.ts:629</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L629">StoriiiesViewer.ts:629</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_expandServiceID" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#expand<wbr/>ServiceID</span><a href="#_expandServiceID" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -427,7 +427,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L226">StoriiiesViewer.ts:226</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L226">StoriiiesViewer.ts:226</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getActiveCanvasAnnotations" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Active<wbr/>Canvas<wbr/>Annotations</span><a href="#_getActiveCanvasAnnotations" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -438,7 +438,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Annotation</span><span class="tsd-signature-symbol">[]</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L680">StoriiiesViewer.ts:680</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L680">StoriiiesViewer.ts:680</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getAnnotationPages" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Annotation<wbr/>Pages</span><a href="#_getAnnotationPages" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -450,7 +450,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">AnnotationPage</span><span class="tsd-signature-symbol">[]</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L638">StoriiiesViewer.ts:638</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L638">StoriiiesViewer.ts:638</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_getRegion" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#get<wbr/>Region</span><a href="#_getRegion" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -466,7 +466,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type ">Rect</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L688">StoriiiesViewer.ts:688</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L688">StoriiiesViewer.ts:688</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_initManifest" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#init<wbr/>Manifest</span><a href="#_initManifest" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -477,7 +477,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L235">StoriiiesViewer.ts:235</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L235">StoriiiesViewer.ts:235</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_initViewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#init<wbr/>Viewer</span><a href="#_initViewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -488,7 +488,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L303">StoriiiesViewer.ts:303</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L303">StoriiiesViewer.ts:303</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_insertInfoAndControls" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#insert<wbr/>Info<wbr/>And<wbr/>Controls</span><a href="#_insertInfoAndControls" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -499,7 +499,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L485">StoriiiesViewer.ts:485</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L485">StoriiiesViewer.ts:485</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_logger" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#logger</span><a href="#_logger" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -517,7 +517,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L205">StoriiiesViewer.ts:205</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L205">StoriiiesViewer.ts:205</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-is-private"><a id="_updateViewer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagPrivate">Private</code> <span>#update<wbr/>Viewer</span><a href="#_updateViewer" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-is-private">
@@ -528,7 +528,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L344">StoriiiesViewer.ts:344</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L344">StoriiiesViewer.ts:344</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/api/interfaces/StoriiiesViewerConfig.html
+++ b/docs/api/interfaces/StoriiiesViewerConfig.html
@@ -24,7 +24,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">StoriiiesViewerConfig</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L24">StoriiiesViewer.ts:24</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L24">StoriiiesViewer.ts:24</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -45,7 +45,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L25">StoriiiesViewer.ts:25</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L25">StoriiiesViewer.ts:25</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifestUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest<wbr/>Url</span><a href="#manifestUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest<wbr/>Url</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -53,12 +53,12 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L26">StoriiiesViewer.ts:26</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L26">StoriiiesViewer.ts:26</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="showCreditSlide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>show<wbr/>Credit<wbr/>Slide</span><a href="#showCreditSlide" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">show<wbr/>Credit<wbr/>Slide</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L27">StoriiiesViewer.ts:27</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/dbb783b/src/StoriiiesViewer.ts#L27">StoriiiesViewer.ts:27</a></li></ul></aside></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/api/interfaces/StoriiiesViewerConfig.html
+++ b/docs/api/interfaces/StoriiiesViewerConfig.html
@@ -24,7 +24,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">StoriiiesViewerConfig</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L24">StoriiiesViewer.ts:24</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L24">StoriiiesViewer.ts:24</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -45,7 +45,7 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L25">StoriiiesViewer.ts:25</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L25">StoriiiesViewer.ts:25</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="manifestUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>manifest<wbr/>Url</span><a href="#manifestUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">manifest<wbr/>Url</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -53,12 +53,12 @@
 </div>
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L26">StoriiiesViewer.ts:26</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L26">StoriiiesViewer.ts:26</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="showCreditSlide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>show<wbr/>Credit<wbr/>Slide</span><a href="#showCreditSlide" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">show<wbr/>Credit<wbr/>Slide</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/b3f3622/src/StoriiiesViewer.ts#L27">StoriiiesViewer.ts:27</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/CogappLabs/StoriiiesViewer/blob/d7eba8e/src/StoriiiesViewer.ts#L27">StoriiiesViewer.ts:27</a></li></ul></aside></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,10 @@ export function nl2br(dirty: string): string {
   return dirty.replace(/(?:\r\n|\r|\n)/g, "<br/>");
 }
 
+/**
+ * If string starts with < and ends with >, it's probably HTML
+ * See: https://iiif.io/api/cookbook/recipe/0007-string-formats/#implementation-notes
+ */
 export function IIIFSaysThisIsHTML(str: string): boolean {
-  return /^<.*>$/gim.test(str);
+  return /^<[\s\S]*>$/gi.test(str);
 }


### PR DESCRIPTION
- **Pivotal ticket**: [#186906726](https://www.pivotaltracker.com/story/show/186906726) (if applicable)

# What does this Pull Request do?

The regular expression in `IIIFSaysThisIsHTML` returned a false negative if `\n` appeared inside a HTML string owing to `.` **not** capturing whitespace characters. 

**For reference:**
`.` = any character
`\s` = any whitespace character
`\S` = any non-whitespace character

As a result this issue only effects manifests which mix HTML and newline characters (which is technically incorrect. The newlines should be ignored in a HTML context, but should be included in the regex in order to match correctly).

We noticed this in manifests that came out of StoriiiesEditor, but that has been patched separately to replace `\n` with `<br>` (these were statically wrapped in a `<p>` tag, qualifying them as HTML).

I also removed the `m` flag a this shouldn't be needed.

N.B.
I tried to see if this would be easy enough to add a new test fixture and assertion in Cypress, but it seems to have trouble comparing the fixture value when mixing HTML and plain text newline characters 


# Test coverage

Yes/No: Are changes in this pull-request covered by:

- [ ] Cypress tests?

# Interested parties

@tristanr-cogapp
